### PR TITLE
add install R from quarto-dev/quarto-actions

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -28,3 +28,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # this secret is always available for github actions
       
+      - name: Install R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.2.0' # The R version to download (if necessary) and use.


### PR DESCRIPTION
HI @bdturley ! 

This will install R so your GitHub Action is able to publish your quarto files that have R in them :)

From: https://github.com/quarto-dev/quarto-actions/blob/main/examples/example-03-dependencies.md